### PR TITLE
Add government paas page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,3 +58,6 @@ groups:
     repos:
       - fourth-wall
       - showtime
+
+# Build settings
+markdown: redcarpet

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,5 @@
+<head>
+  <meta charset='utf-8' />
+  <title>Government Digital Service on GitHub</title>
+  <link rel="stylesheet" href="/gds.css">
+</head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+  {% include head.html %}
+
+    <body>
+
+    <div class="page-content">
+      <div class="wrap">
+      {{ content }}
+      </div>
+    </div>
+
+    </body>
+</html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+<div class="post">
+
+  <header class="post-header">
+    <h1>{{ page.title }}</h1>
+  </header>
+
+  <article class="post-content">
+  {{ content }}
+  </article>
+
+</div>

--- a/government-paas.md
+++ b/government-paas.md
@@ -4,5 +4,11 @@ title: Government PaaS
 permalink: /government-paas/
 ---
 We are prototyping a Government Platform as a Service. For more information,
-please read [our blog
-post](https://gds.blog.gov.uk/2015/09/08/building-a-platform-to-host-digital-services/).
+please read our blog posts:
+[Building a platform to host digital services](https://gds.blog.gov.uk/2015/09/08/building-a-platform-to-host-digital-services/)
+
+[Looking at open source PaaS
+technologies](https://gdstechnology.blog.gov.uk/2015/10/27/looking-at-open-source-paas-technologies/)
+
+We are coding in the open. All our repos are in the [GDS GitHub
+organisation](https://github.com/alphagov/).

--- a/government-paas.md
+++ b/government-paas.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Government PaaS
+permalink: /government-paas/
+---
+page

--- a/government-paas.md
+++ b/government-paas.md
@@ -3,4 +3,6 @@ layout: page
 title: Government PaaS
 permalink: /government-paas/
 ---
-page
+We are prototyping a Government Platform as a Service. For more information,
+please read [our blog
+post](https://gds.blog.gov.uk/2015/09/08/building-a-platform-to-host-digital-services/).


### PR DESCRIPTION
This PR adds a `/government-paas/` page which lists all our repos. For now, this is both entirely manual and not very user-friendly in terms of reading it. There are various ways we could make this better; for example using something closer to how the repos are [generated for the index page](https://github.com/alphagov/alphagov.github.io/blob/master/index.html#L38-L63); however, I'm not sure when I'll get a chance to work on this next so wanted to commit where I'd got to.

Currently this page is not linked to from anywhere, even the index page.

Anyone please feel free to review but tagging @dcarley as it's for our team.

cc @jystewart 