### PR TITLE
Update list of projects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,24 +2,29 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - update-directory-index.sh
 
 groups:
-  advice_and_guidance:
+  guidance_on_digital_services:
     name: Guidance on digital services
     bio: We create and maintain guidance on creating great digital government services.
-    repos:
-      - government-service-design-manual
-      - design-principles
-      - service-domain-checker
-  govuk_look_feel:
+    links:
+      - name: Service Manual
+        url: https://www.gov.uk/service-manual
+        description: Helping government teams create and run great digital services that meet the Digital Service Standard.
+      - name: Government Design Principles
+        url: https://www.gov.uk/design-principles
+        description: The UK government's design principles and examples of how they've been used.
+      - name: Service Toolkit
+        url: https://www.gov.uk/service-toolkit
+        description: All you need to design, build and run services that meet government standards.
+  govuk_templates_and_styles:
     name: GOV.UK templates and styles
     bio: |
-      GDS offers templates and styles to help government departments create services that fit the
+      We offer templates and styles to help government departments create services that fit the
       GOV.UK look and feel.
     repos:
-      - govuk_template
-      - govuk_frontend_toolkit
-      - govuk_elements
+      - govuk-frontend
   transitioning_to_govuk:
     name: Transitioning to GOV.UK
     bio: |
@@ -28,9 +33,9 @@ groups:
       <a href='https://gds.blog.gov.uk/2012/10/11/no-link-left-behind/'>No Link Left Behind</a> and
       <a href='https://gds.blog.gov.uk/2012/12/10/testing-the-redirections/'>Testing The Redirections</a>.
     repos:
-      - transition
       - bouncer
-      - redirector
+      - transition
+      - side-by-side-browser
   performance_platform:
     name: Performance Platform
     bio: |
@@ -39,25 +44,26 @@ groups:
       government over time. We occasionally post on the
       <a href='https://gdsdata.blog.gov.uk/'>Data at GDS</a> blog.
     repos:
-      - spotlight
       - backdrop
-      - pp-puppet
+      - cheapseats
+      - spotlight
+      - stagecraft
   libraries_and_utilities:
     name: Libraries and utilities
     repos:
-      - unicornherder
-      - fake_google_analytics
-      - character_encoding_cleaner
-      - google-auth-bridge
+      - govuk-browser-extension
+      - govuk-saas-config
       - magna-charta
-      - rack-geo
       - sbv-to-ttaf
+      - sidekiq-monitoring
   office_tools:
     name: Tools for the office
-    bio: We have a lot of code that shows up on displays around our office.
+    bio: We have a lot of code that shows up on displays around our office or posts in our Slack channels.
     repos:
       - fourth-wall
+      - gds-hubot
+      - govuk-display-screen
+      - govuk-dependencies
+      - govuk-deploy-lag-badger
+      - seal
       - showtime
-
-# Build settings
-markdown: redcarpet

--- a/index.html
+++ b/index.html
@@ -38,23 +38,39 @@
           <p>{{ group[1].bio }}</p>
         {% endif %}
 
-        {% for repo in group[1].repos %}
-          {% comment %}
-            Iterate over all alphagov repos each time we try to output a repo.
-            We do this because there's no way to select an element from an array with Liquid.
-          {% endcomment %}
-          {% for alphagov_repo in site.github.public_repositories %}
-            {% if alphagov_repo.name == repo %}
-              <div class="repo">
-                <a href="{{ alphagov_repo.html_url }}">
-                  <h3>{{ alphagov_repo.name }}</h3>
-                </a>
-                <p>{{ alphagov_repo.description }}</p>
-                <p>Created in {{ alphagov_repo.created_at | date: '%B %Y' }}, last updated in {{ alphagov_repo.updated_at | date: '%B %Y' }}. Written in {{ alphagov_repo.language }}.</p>
-              </div>
-            {% endif %}
+        {% if group[1].repos %}
+          {% for repo in group[1].repos %}
+            {% comment %}
+              Iterate over all alphagov repos each time we try to output a repo.
+              We do this because there's no way to select an element from an array with Liquid.
+            {% endcomment %}
+            {% for alphagov_repo in site.github.public_repositories %}
+              {% if alphagov_repo.name == repo %}
+                <div class="repo">
+                  <a href="{{ alphagov_repo.html_url }}">
+                    <h3>{{ alphagov_repo.name }}</h3>
+                  </a>
+                  <p>{{ alphagov_repo.description }}</p>
+                  <p>Created in {{ alphagov_repo.created_at | date: '%B %Y' }}, last updated in {{ alphagov_repo.updated_at | date: '%B %Y' }}. Written in {{ alphagov_repo.language }}.</p>
+                </div>
+              {% endif %}
+            {% endfor %}
           {% endfor %}
-        {% endfor %}
+        {% endif %}
+
+        {% if group[1].links %}
+          {% for link in group[1].links %}
+            {% comment %}
+              Display non-repository links with custom messages
+            {% endcomment %}
+            <div class="repo">
+              <a href="{{ link.url }}">
+                <h3>{{ link.name }}</h3>
+              </a>
+              <p>{{ link.description }}</p>
+            </div>
+          {% endfor %}
+        {% endif %}
 
       </section>
     {% endfor %}


### PR DESCRIPTION
This commit updates the list of project repos. Most of then existing ones have been archived, deleted or moved so they are removed here and new ones added.

The ability to add non-repo links has also been added since guidance is no longer contained in a repo.

Finally, use of the redcarpet Markdown parser is removed, since this has been deprecated by GitHub.