### PR TITLE
Improve text and link readability

### DIFF
--- a/data-ethics-and-society-reading-group/index.html
+++ b/data-ethics-and-society-reading-group/index.html
@@ -2,9 +2,9 @@
   <head>
     <meta http-equiv="refresh" content="0; https://data-ethics-and-society.github.io/data-ethics-and-society-reading-group/">
     <style>
-      body { color: #333; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 40px; }
-      a { color: #2b8cc4; }
-      p { font-size: 1.4em; line-height: 1.5em; max-width: 66%; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      a { color: #1a65a6; }
+      p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }
     </style>
 
   </head>

--- a/data-ethics-and-society-reading-group/index.html
+++ b/data-ethics-and-society-reading-group/index.html
@@ -1,8 +1,9 @@
 <html>
   <head>
     <meta http-equiv="refresh" content="0; https://data-ethics-and-society.github.io/data-ethics-and-society-reading-group/">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
-      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0 clamp(20px, 5vw, 40px); }
       a { color: #1a65a6; }
       p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }
     </style>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Government Digital Service on GitHub</title>
     <style>
-      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0 clamp(20px, 5vw, 40px); }
       h1 { font-weight: 500; font-size: 2.4em; }
       a { color: #1a65a6; }
       p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
       <p>
         The <a href="https://gds.blog.gov.uk/">Government Digital Service</a> is a unit of the UK's
         Department for Science, Innovation and Technology, tasked with transforming government services. 
-       <br>
+      </p>
+
+      <p>
        We have a practice of
         <a href="https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/">Coding In The Open</a>,
         which means that a lot of public repositories end up on

--- a/index.html
+++ b/index.html
@@ -4,22 +4,23 @@
     <meta charset="utf-8" />
     <title>Government Digital Service on GitHub</title>
     <style>
-      body { color: #333; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
-      h1 { color: #000; font-weight: 500; font-size: 2.4em; }
-      a { color: #2b8cc4; }
-      p { font-size: 1.4em; line-height: 1.5em; margin: 0.8em 0; max-width: 66%; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      h1 { font-weight: 500; font-size: 2.4em; }
+      a { color: #1a65a6; }
+      p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }
     </style>
   </head>
   <body>
 
-    <section id="intro">
+    <main>
 
       <h1>Government Digital Service</h1>
 
       <p>
         The <a href="https://gds.blog.gov.uk/">Government Digital Service</a> is a unit of the UK's
         Department for Science, Innovation and Technology, tasked with transforming government services. 
-        We have a practice of
+       <br>
+       We have a practice of
         <a href="https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/">Coding In The Open</a>,
         which means that a lot of public repositories end up on
         <a href="https://github.com/alphagov">our GitHub organisation</a>.
@@ -31,7 +32,7 @@
        to the  <a href="https://www.sign-in.service.gov.uk/">GOV.UK One Login</a> programme.
       </p>
 
-    </section>
+    </main>
 
   </body>
 </html>

--- a/wcag-primer/index.html
+++ b/wcag-primer/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta http-equiv="refresh" content="0; https://alphagov.github.io/guide-to-wcag/">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guide to WCAG - redirect</title>
     <style>
-      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; margin: 0; padding: 0 clamp(20px, 5vw, 40px); }
       h1 { font-weight: 500; font-size: 2.4em; }
       a { color: #1a65a6; }
       p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }

--- a/wcag-primer/index.html
+++ b/wcag-primer/index.html
@@ -4,9 +4,10 @@
     <meta http-equiv="refresh" content="0; https://alphagov.github.io/guide-to-wcag/">
     <title>Guide to WCAG - redirect</title>
     <style>
-      body { color: #333; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 40px; }
-      a { color: #2b8cc4; }
-      p { font-size: 1.4em; line-height: 1.5em; max-width: 66%; }
+      body { color: #0b0c0c; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; padding: 0 40px; }
+      h1 { font-weight: 500; font-size: 2.4em; }
+      a { color: #1a65a6; }
+      p { font-size: 1.4em; line-height: 1.5; margin: 0.8em 0; max-width: 66ch; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Came across this page and noticed it seemed to have issues with the link contrast so made some improvements:

- change the line length of the text to be based on character length, rather than 66% which could be more or less readable depending on the user's screen size.
- use the recommended `main` landmark instead of generic `section`
- allow text to be larger and readable using the meta viewport tag alongside variable padding
- align the colours with the current GOV.UK Design System guidance: https://design-system.service.gov.uk/styles/colour/
- improve link contrast from a ratio of 3.71:1 which only will meet level AA for 'large text' to 6.07:1 which [meets all requirements](https://www.w3.org/TR/WCAG22/#contrast-minimum). 

## Screenshots

### Smaller screens

| Before | After |
| - | - |
| ![Screenshot of a simulated mobile device with small text](https://github.com/user-attachments/assets/cdd7c3b9-1f46-47a0-9c4d-4194431c22ff) | ![Screenshot of a simulated mobile device with larger text](https://github.com/user-attachments/assets/74ea1ee1-8885-4f2b-8e98-8a743ac12d8e)

### Larger screens

| Before | After |
| - | - |
| ![Screenshot of a simulated laptop viewport with light blue links](https://github.com/user-attachments/assets/25dc2db9-aabc-4765-ba2f-b06cfa631325) | ![Screenshot of a simulated laptop viewport with darker blue links](https://github.com/user-attachments/assets/a39cb5e6-6828-4e3d-b24f-63a33b3311c0) |
